### PR TITLE
correct loss fn + preprocess + knowledge graph

### DIFF
--- a/scripts/CMU/knowledge_graph.py
+++ b/scripts/CMU/knowledge_graph.py
@@ -12,9 +12,9 @@ class KnowledgeGraph(object):
         self._preprocess = Preprocessor()
 
     def _update_line(self, line, graph, context_so_far):
-        ent_pattern = r"\[[a-zA-Z0-9 ]+\([a-zA-Z ]+\[\d+\]\)\]?"
-        ref_pattern = r"\[[a-zA-Z0-9 ]+\]"
-        words = r"[a-zA-Z0-9 ]+"
+        ent_pattern = r"\[[a-zA-Z0-9' ]+\([a-zA-Z]+\[\d+\]\)\]"
+        ref_pattern = r"\[[a-zA-Z0-9' ]+\]"
+        words = r"[a-zA-Z0-9' ]+"
         entities = re.findall(ent_pattern, line)
         new_line = line
 


### PR DESCRIPTION
Changed loss function to BCEWithLogits
Preprocessing now includes question tags in the IDs as:

"<uuid>,<tag1>,<tag2>,<tag3>,...,<tagN>"

tagi could be of the form "<entity>@<id>" or <attribute>

files after preprocessing contains "dijkstra" key in the same level as
"title".

Dijkstra's entries are dj[src_node][dest_node] = dist <integer>
src_node/dst_node could be of the form "<entity>-<id>" or "<attribute>"

Note that in dijkstra the entity-id is different from entity@id in the
question tags